### PR TITLE
removed nas reference

### DIFF
--- a/docs/system-administrators/system-maintenance.md
+++ b/docs/system-administrators/system-maintenance.md
@@ -4,7 +4,7 @@
 
 If **Scout** is running, it automatically checks this folder periodically for new images and copies them for internal storage and processing. Images added to this folder disappear from the Ubuntu desktop folder as **Scout** imports them.
  
-Note: Anyone who has access to the **Scout** Server or the NAS remotely can copy aerial survey images into the `/data/scout/nas/images` folder.
+Note: Anyone who has access to the **Scout** Server or the NAS remotely can copy aerial survey images into the `/data/scout/images` folder.
  
 An alert bar displays in **Scout** when image ingestion is in progress, warning users that new images are being added and therefore not all images may be available for task creation.
 


### PR DESCRIPTION
setup has been generalized, so no more specific references to nas in docs or product. should match image file references across system admin docs